### PR TITLE
Installation order according to official docs

### DIFF
--- a/tasks/rhel.yml
+++ b/tasks/rhel.yml
@@ -61,15 +61,13 @@
     - name: Enable cuda repository meta-data (RHEL 9)
       ansible.builtin.command:
         cmd: "dnf config-manager --add-repo {{ cuda_rhel9_url }}"
-    - name: Update to latest nvidia driver
-      ansible.builtin.dnf:
-        name: '@nvidia-driver:latest-dkms'
-        state: present
-        allowerasing: true
     - name: Install CUDA (RHEL 9)
       ansible.builtin.package:
         name: "{{ cuda_rhel9_package_name }}"
         state: present
         update_cache: true
-        allowerasing: true
       when: install_cuda | bool
+    - name: Update to latest nvidia driver
+      ansible.builtin.dnf:
+        name: '@nvidia-driver:latest-dkms'
+        state: present

--- a/tasks/rhel.yml
+++ b/tasks/rhel.yml
@@ -67,8 +67,3 @@
         state: installed
         update_cache: true
       when: install_cuda | bool
-    - name: Update to latest nvidia driver
-      ansible.builtin.dnf:
-        name: '@nvidia-driver:latest-dkms'
-        state: present
-        allowerasing: true

--- a/tasks/rhel.yml
+++ b/tasks/rhel.yml
@@ -69,6 +69,7 @@
     - name: Install CUDA (RHEL 9)
       ansible.builtin.package:
         name: "{{ cuda_rhel9_package_name }}"
-        state: installed
+        state: present
         update_cache: true
+        allowerasing: true
       when: install_cuda | bool

--- a/tasks/rhel.yml
+++ b/tasks/rhel.yml
@@ -67,7 +67,3 @@
         state: present
         update_cache: true
       when: install_cuda | bool
-    - name: Update to latest nvidia driver
-      ansible.builtin.dnf:
-        name: '@nvidia-driver:latest-dkms'
-        state: present

--- a/tasks/rhel.yml
+++ b/tasks/rhel.yml
@@ -61,6 +61,11 @@
     - name: Enable cuda repository meta-data (RHEL 9)
       ansible.builtin.command:
         cmd: "dnf config-manager --add-repo {{ cuda_rhel9_url }}"
+    - name: Update to latest nvidia driver
+      ansible.builtin.dnf:
+        name: '@nvidia-driver:latest-dkms'
+        state: present
+        allowerasing: true
     - name: Install CUDA (RHEL 9)
       ansible.builtin.package:
         name: "{{ cuda_rhel9_package_name }}"


### PR DESCRIPTION
Could fix sub-issue no 2 in #3 
This should align with the installation procedure in the [official docs](https://developer.nvidia.com/cuda-12-1-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=Rocky&target_version=9&target_type=rpm_network)
![image](https://github.com/user-attachments/assets/5e36f811-c1d5-468d-a83e-7c9ec370e75b)
